### PR TITLE
Chore/use ts runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,16 +15,30 @@
         "@eslint/compat": "^1.3.2",
         "@eslint/js": "^9.34.0",
         "@stylistic/eslint-plugin": "^5.3.1",
+        "@types/node": "^24.3.1",
         "eslint": "^9.34.0",
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.32.0",
         "globals": "^16.3.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.1.6",
+        "ts-node": "^10.9.2",
         "typescript-eslint": "^8.42.0"
       },
       "peerDependencies": {
         "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -397,6 +411,31 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.1.7",
       "license": "MIT",
@@ -507,6 +546,30 @@
         "eslint": ">=9.0.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -553,9 +616,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -1104,6 +1168,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1161,6 +1237,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1485,6 +1567,12 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1604,6 +1692,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/discord-api-types": {
@@ -3270,6 +3367,12 @@
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
       "integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA=="
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4362,6 +4465,49 @@
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
       "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -4530,7 +4676,8 @@
     "node_modules/undici-types": {
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "license": "MIT"
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
@@ -4574,6 +4721,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -4763,6 +4916,15 @@
         "node": ">= 14.6"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -4777,6 +4939,15 @@
     }
   },
   "dependencies": {
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      }
+    },
     "@discordjs/builders": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.11.3.tgz",
@@ -5023,6 +5194,28 @@
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true
     },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@mongodb-js/saslprep": {
       "version": "1.1.7",
       "requires": {
@@ -5106,6 +5299,30 @@
         "picomatch": "^4.0.3"
       }
     },
+    "@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -5145,9 +5362,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "requires": {
         "undici-types": "~7.10.0"
       }
@@ -5468,6 +5685,15 @@
       "dev": true,
       "requires": {}
     },
+    "acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.11.0"
+      }
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -5503,6 +5729,12 @@
       "requires": {
         "color-convert": "^2.0.1"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "2.0.1",
@@ -5733,6 +5965,12 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5812,6 +6050,12 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "discord-api-types": {
       "version": "0.38.22",
@@ -6956,6 +7200,12 @@
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
       "integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA=="
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7643,6 +7893,27 @@
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
       "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
     },
+    "ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      }
+    },
     "tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -7799,6 +8070,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
     "webidl-conversions": {
       "version": "7.0.0"
     },
@@ -7914,6 +8191,12 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,7 @@
   "module": "src/index.ts",
   "type": "module",
   "scripts": {
-    "dev": "node --loader ts-node/esm src/index.ts",
-    "start": "node ./build/index.js",
-    "build": "tsc --build --verbose",
-    "deployCommands": "node ./build/discord/deployCommands.js",
+    "start": "node --loader ts-node/esm src/index.ts",
     "prepare": "husky",
     "lint": "eslint ."
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "module": "src/index.ts",
   "type": "module",
   "scripts": {
+    "dev": "node --loader ts-node/esm src/index.ts",
     "start": "node ./build/index.js",
     "build": "tsc --build --verbose",
     "deployCommands": "node ./build/discord/deployCommands.js",
@@ -22,12 +23,14 @@
     "@eslint/compat": "^1.3.2",
     "@eslint/js": "^9.34.0",
     "@stylistic/eslint-plugin": "^5.3.1",
+    "@types/node": "^24.3.1",
     "eslint": "^9.34.0",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
     "globals": "^16.3.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.6",
+    "ts-node": "^10.9.2",
     "typescript-eslint": "^8.42.0"
   }
 }

--- a/src/discord/DiscordManager.ts
+++ b/src/discord/DiscordManager.ts
@@ -1,6 +1,6 @@
 import { GatewayIntentBits, Events } from 'discord.js';
 
-import MiddlewareManager from '../utils/MiddlewareManager.js';
+import middlewareManager from '../utils/MiddlewareManager.js';
 import TicketCollectorModel from '../schema/collectors/TicketCollector.js';
 import ExtendedClient from "./ExtendedClient.js";
 import EventHandler from './EventHandler.js';
@@ -25,7 +25,7 @@ class DiscordManager {
 
   private async setup() {
     try {
-      (new MiddlewareManager).setClient(this.client);
+      middlewareManager.setClient(this.client);
             
       await this.client.setupCommands();
       this.setupGateway();
@@ -38,7 +38,7 @@ class DiscordManager {
   }
 
   private setupGateway() {
-    this.client.on('ready', async () => {
+    this.client.on('clientReady', async () => {
       if (!this.client.user) {
         return;
       }

--- a/src/discord/DiscordManager.ts
+++ b/src/discord/DiscordManager.ts
@@ -1,9 +1,9 @@
 import { GatewayIntentBits, Events } from 'discord.js';
 
-import middlewareManager from '../utils/MiddlewareManager.js';
-import TicketCollectorModel from '../schema/collectors/TicketCollector.js';
+import middlewareManager from '../utils/MiddlewareManager.ts';
+import TicketCollectorModel from '../schema/collectors/TicketCollector.ts';
 import ExtendedClient from "./ExtendedClient.js";
-import EventHandler from './EventHandler.js';
+import EventHandler from './EventHandler.ts';
 
 
 class DiscordManager {

--- a/src/discord/EventHandler.ts
+++ b/src/discord/EventHandler.ts
@@ -1,6 +1,6 @@
 import EventModel from '../schema/events/Event.js';
 import TicketCollectorModel from '../schema/collectors/TicketCollector.js';
-import settings from '../data/settings.json' assert { type: "json" };
+import settings from '../data/settings.json' with { type: "json" };
 
 import type DiscordManager from './DiscordManager.js';
 

--- a/src/discord/EventHandler.ts
+++ b/src/discord/EventHandler.ts
@@ -1,8 +1,8 @@
-import EventModel from '../schema/events/Event.js';
-import TicketCollectorModel from '../schema/collectors/TicketCollector.js';
+import EventModel from '../schema/events/Event.ts';
+import TicketCollectorModel from '../schema/collectors/TicketCollector.ts';
 import settings from '../data/settings.json' with { type: "json" };
 
-import type DiscordManager from './DiscordManager.js';
+import type DiscordManager from './DiscordManager.ts';
 
 
 const { eventLoopInterval } = settings.discord;

--- a/src/discord/ExtendedClient.ts
+++ b/src/discord/ExtendedClient.ts
@@ -14,11 +14,6 @@ interface CustomCommand extends ClientOptions {
   execute: <T>(interaction: ChatInputCommandInteraction) => Promise<T>;
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const __filename = fileURLToPath(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const __dirname = dirname(__filename);
-
 class ExtendedClient extends Client {
   commands: Collection<string, CustomCommand>;
 
@@ -28,8 +23,8 @@ class ExtendedClient extends Client {
   }
 
   public async setupCommands() {
-    const commandDir = path.join(__dirname, 'commands');
-    const commandFiles = fs.readdirSync(commandDir).filter(file => file.endsWith('.js'));
+    const commandDir = path.join(dirname(fileURLToPath(import.meta.url)), 'commands');
+    const commandFiles = fs.readdirSync(commandDir).filter(file => file.endsWith('.ts'));
 
     for (const commandFile of commandFiles) {
       const commandPath = path.join(commandDir, commandFile);

--- a/src/discord/commands/config.ts
+++ b/src/discord/commands/config.ts
@@ -4,7 +4,7 @@ import {
 } from "discord.js";
 
 import GuildModel from "../../schema/main/PoliticalGuild.js";
-import settings from "../../data/settings.json" assert { type: 'json' };
+import settings from "../../data/settings.json" with { type: 'json' };
 import init from "./subcommands/init.js";
 import executeDelete from "./subcommands/delete.js";
 

--- a/src/discord/commands/eval.ts
+++ b/src/discord/commands/eval.ts
@@ -1,7 +1,7 @@
 import util from "util";
 import { SlashCommandBuilder, type ChatInputCommandInteraction } from "discord.js";
 
-import settings from "../../data/settings.json" assert { type: "json" };
+import settings from "../../data/settings.json" with { type: "json" };
 
 
 const data = new SlashCommandBuilder()

--- a/src/discord/commands/subcommands/delete.ts
+++ b/src/discord/commands/subcommands/delete.ts
@@ -4,7 +4,7 @@ import {
 } from "discord.js";
 
 import PoliticalGuild from "../../../schema/main/PoliticalGuild.js";
-import settings from "../../../data/settings.json" assert { type: "json" };
+import settings from "../../../data/settings.json" with { type: "json" };
 
 
 export default async function executeDelete(

--- a/src/discord/commands/subcommands/init.ts
+++ b/src/discord/commands/subcommands/init.ts
@@ -5,17 +5,17 @@ import {
 } from 'discord.js';
 import { isDocument } from '@typegoose/typegoose';
 
-import { PoliticalRoleModel } from '../../../schema/roles/PoliticalRole.js';
-import PoliticalGuild from '../../../schema/main/PoliticalGuild.js';
+import { PoliticalRoleModel } from '../../../schema/roles/PoliticalRole.ts';
+import PoliticalGuild from '../../../schema/main/PoliticalGuild.ts';
 import settings from '../../../data/settings.json' with { type: 'json' };
 import wizardDefaults from '../../../data/defaults/wizard.json' with { type: 'json' };
-import SystemWizard from './wizardfragments/system.js';
-import LegislatureWizard from './wizardfragments/legislature.js';
-import JudicialWizard from './wizardfragments/judicial.js';
-import DiscordWizard from './wizardfragments/discord.js';
+import SystemWizard from './wizardfragments/system.ts';
+import LegislatureWizard from './wizardfragments/legislature.ts';
+import JudicialWizard from './wizardfragments/judicial.ts';
+import DiscordWizard from './wizardfragments/discord.ts';
 
 
-import type { GuildConfigData } from '../../../types/wizard.js';
+import type { GuildConfigData } from '../../../types/wizard.ts';
 
 
 export default async function init(interaction: ChatInputCommandInteraction): Promise<boolean> {

--- a/src/discord/commands/subcommands/init.ts
+++ b/src/discord/commands/subcommands/init.ts
@@ -7,8 +7,8 @@ import { isDocument } from '@typegoose/typegoose';
 
 import { PoliticalRoleModel } from '../../../schema/roles/PoliticalRole.js';
 import PoliticalGuild from '../../../schema/main/PoliticalGuild.js';
-import settings from '../../../data/settings.json' assert { type: 'json' };
-import wizardDefaults from '../../../data/defaults/wizard.json' assert { type: 'json' };
+import settings from '../../../data/settings.json' with { type: 'json' };
+import wizardDefaults from '../../../data/defaults/wizard.json' with { type: 'json' };
 import SystemWizard from './wizardfragments/system.js';
 import LegislatureWizard from './wizardfragments/legislature.js';
 import JudicialWizard from './wizardfragments/judicial.js';

--- a/src/discord/commands/subcommands/wizardfragments/discord.ts
+++ b/src/discord/commands/subcommands/wizardfragments/discord.ts
@@ -4,17 +4,17 @@ import {
   type MessageComponentInteraction, type APIEmbedField
 } from 'discord.js';
 
-import { PoliticalSystemType } from '../../../../types/systems.js';
-import { PoliticalRoleHierarchy } from '../../../../types/permissions.js';
+import { PoliticalSystemType } from '../../../../types/systems.ts';
+import { PoliticalRoleHierarchy } from '../../../../types/permissions.ts';
 import settings from '../../../../data/settings.json' with { type: 'json' };
 import roleDefaults from '../../../../data/defaults/roles.json' with { type: 'json' };
 import categoryDefaults from '../../../../data/defaults/channels.json' with { type: "json" };
-import BaseWizard from './BaseWizard.js';
+import BaseWizard from './BaseWizard.ts';
 
 import type {
   DefaultRoleData, DiscordRoleHolderData,
   ExtendedDefaultDiscordData, NewCategoryChannelData
-} from '../../../../types/wizard.js';
+} from '../../../../types/wizard.ts';
 
 
 class DiscordWizard extends BaseWizard {

--- a/src/discord/commands/subcommands/wizardfragments/discord.ts
+++ b/src/discord/commands/subcommands/wizardfragments/discord.ts
@@ -6,9 +6,9 @@ import {
 
 import { PoliticalSystemType } from '../../../../types/systems.js';
 import { PoliticalRoleHierarchy } from '../../../../types/permissions.js';
-import settings from '../../../../data/settings.json' assert { type: 'json' };
-import roleDefaults from '../../../../data/defaults/roles.json' assert { type: 'json' };
-import categoryDefaults from '../../../../data/defaults/channels.json' assert { type: "json" };
+import settings from '../../../../data/settings.json' with { type: 'json' };
+import roleDefaults from '../../../../data/defaults/roles.json' with { type: 'json' };
+import categoryDefaults from '../../../../data/defaults/channels.json' with { type: "json" };
 import BaseWizard from './BaseWizard.js';
 
 import type {

--- a/src/discord/commands/subcommands/wizardfragments/judicial.ts
+++ b/src/discord/commands/subcommands/wizardfragments/judicial.ts
@@ -1,8 +1,8 @@
 import { ButtonBuilder, EmbedBuilder, ActionRowBuilder, Colors, ButtonStyle } from 'discord.js';
 
 
-import settings from '../../../../data/settings.json' assert { type: 'json' };
-import wizardDefaults from '../../../../data/defaults/wizard.json' assert { type: 'json' };
+import settings from '../../../../data/settings.json' with { type: 'json' };
+import wizardDefaults from '../../../../data/defaults/wizard.json' with { type: 'json' };
 import BaseWizard from './BaseWizard.js';
 
 

--- a/src/discord/commands/subcommands/wizardfragments/judicial.ts
+++ b/src/discord/commands/subcommands/wizardfragments/judicial.ts
@@ -3,7 +3,7 @@ import { ButtonBuilder, EmbedBuilder, ActionRowBuilder, Colors, ButtonStyle } fr
 
 import settings from '../../../../data/settings.json' with { type: 'json' };
 import wizardDefaults from '../../../../data/defaults/wizard.json' with { type: 'json' };
-import BaseWizard from './BaseWizard.js';
+import BaseWizard from './BaseWizard.ts';
 
 
 class JudicialWizard extends BaseWizard {

--- a/src/discord/commands/subcommands/wizardfragments/legislature.ts
+++ b/src/discord/commands/subcommands/wizardfragments/legislature.ts
@@ -1,9 +1,9 @@
 import { EmbedBuilder, ActionRowBuilder, ButtonBuilder, Colors, ButtonStyle } from 'discord.js';
 
-import { PoliticalSystemType } from '../../../../types/systems';
+import { PoliticalSystemType } from '../../../../types/systems.ts';
 import settings from '../../../../data/settings.json' with { type: 'json' };
 import wizardDefaults from '../../../../data/defaults/wizard.json' with { type: 'json' };
-import BaseWizard from './BaseWizard.js';
+import BaseWizard from './BaseWizard.ts';
 
 import type { InitWizardFunction } from '../init';
 

--- a/src/discord/commands/subcommands/wizardfragments/legislature.ts
+++ b/src/discord/commands/subcommands/wizardfragments/legislature.ts
@@ -1,8 +1,8 @@
 import { EmbedBuilder, ActionRowBuilder, ButtonBuilder, Colors, ButtonStyle } from 'discord.js';
 
 import { PoliticalSystemType } from '../../../../types/systems';
-import settings from '../../../../data/settings.json' assert { type: 'json' };
-import wizardDefaults from '../../../../data/defaults/wizard.json' assert { type: 'json' };
+import settings from '../../../../data/settings.json' with { type: 'json' };
+import wizardDefaults from '../../../../data/defaults/wizard.json' with { type: 'json' };
 import BaseWizard from './BaseWizard.js';
 
 import type { InitWizardFunction } from '../init';

--- a/src/discord/commands/subcommands/wizardfragments/system.ts
+++ b/src/discord/commands/subcommands/wizardfragments/system.ts
@@ -5,8 +5,8 @@ import {
 } from 'discord.js';
 
 import { PoliticalSystemType } from '../../../../types/systems.js';
-import settings from '../../../../data/settings.json' assert { type: 'json' };
-import wizardDefaults from '../../../../data/defaults/wizard.json' assert { type: 'json' };
+import settings from '../../../../data/settings.json' with { type: 'json' };
+import wizardDefaults from '../../../../data/defaults/wizard.json' with { type: 'json' };
 import BaseWizard from './BaseWizard.js';
 
 

--- a/src/discord/commands/subcommands/wizardfragments/system.ts
+++ b/src/discord/commands/subcommands/wizardfragments/system.ts
@@ -4,10 +4,10 @@ import {
   type APIButtonComponentWithCustomId
 } from 'discord.js';
 
-import { PoliticalSystemType } from '../../../../types/systems.js';
+import { PoliticalSystemType } from '../../../../types/systems.ts';
 import settings from '../../../../data/settings.json' with { type: 'json' };
 import wizardDefaults from '../../../../data/defaults/wizard.json' with { type: 'json' };
-import BaseWizard from './BaseWizard.js';
+import BaseWizard from './BaseWizard.ts';
 
 
 class SystemWizard extends BaseWizard {

--- a/src/discord/deployCommands.ts
+++ b/src/discord/deployCommands.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import { config } from "dotenv";
 import { REST, Routes } from "discord.js";
 
-import settings from "../data/settings.json" assert { type: 'json' };
+import settings from "../data/settings.json" with { type: 'json' };
 
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import mongoose from "mongoose";
 import { config } from 'dotenv';
 
 import DiscordManager from "./discord/DiscordManager.js";
-import settings from "./data/settings.json" assert { type: "json" };
+import settings from "./data/settings.json" with { type: "json" };
 
 
 config();

--- a/src/schema/channels/GuildCategory.ts
+++ b/src/schema/channels/GuildCategory.ts
@@ -4,22 +4,22 @@ import { prop, getModelForClass, type Ref } from '@typegoose/typegoose';
 import ChannelPermissions, {
   ChannelPermissionsInterface,
   type UnfilteredRefRoleArray
-} from '../permissions/ChannelPermissions.js';
-import Chamber from '../main/Chamber.js';
-import createChannel from '../../utils/channelCreationHelper.js';
-import { PoliticalSystemType, PoliticalBranchType } from '../../types/systems.js';
+} from '../permissions/ChannelPermissions.ts';
+import Chamber from '../main/Chamber.ts';
+import createChannel from '../../utils/channelCreationHelper.ts';
+import { PoliticalSystemType, PoliticalBranchType } from '../../types/systems.ts';
 import {
   PoliticalRoleHierarchy,
   type PermissionsOverwriteEnumKeyHolder
-} from '../../types/permissions.js';
+} from '../../types/permissions.ts';
 import {
   AbstractChannelType, ChannelInterface, LogChannelType
-} from '../../types/channels.js';
-import AbstractChannel from './AbstractChannel.js';
+} from '../../types/channels.ts';
+import AbstractChannel from './AbstractChannel.ts';
 
-import type PoliticalRoleHolder from '../roles/PoliticalRoleHolder.js';
-import type { DefaultCategoryData, GuildConfigData } from '../../types/wizard.js';
-import type PoliticalChannel from './PoliticalChannel.js';
+import type PoliticalRoleHolder from '../roles/PoliticalRoleHolder.ts';
+import type { DefaultCategoryData, GuildConfigData } from '../../types/wizard.ts';
+import type PoliticalChannel from './PoliticalChannel.ts';
 
 
 /**

--- a/src/schema/channels/PoliticalChannel.ts
+++ b/src/schema/channels/PoliticalChannel.ts
@@ -1,11 +1,11 @@
 import { TextChannel } from 'discord.js';
 import { prop, type Ref, getDiscriminatorModelForClass } from '@typegoose/typegoose';
 
-import { TicketCollector } from '../collectors/TicketCollector.js';
-import { AbstractChannelType, ChannelInterface } from '../../types/channels.js';
-import AbstractChannel, { AbstractChannelModel } from './AbstractChannel.js';
+import { TicketCollector } from '../collectors/TicketCollector.ts';
+import { AbstractChannelType, ChannelInterface } from '../../types/channels.ts';
+import AbstractChannel, { AbstractChannelModel } from './AbstractChannel.ts';
 
-import type { DefaultInteractionData } from '../../types/collector.js';
+import type { DefaultInteractionData } from '../../types/collector.ts';
 
 
 /**

--- a/src/schema/collectors/TicketCollector.ts
+++ b/src/schema/collectors/TicketCollector.ts
@@ -4,16 +4,16 @@ import {
 } from 'discord.js';
 import { type Ref, isDocument, getDiscriminatorModelForClass } from '@typegoose/typegoose';
 
-import GuildModel from '../main/PoliticalGuild.js';
-import EventModel, { EventSchema } from '../events/Event.js';
-import { PoliticalChannelModel } from '../channels/PoliticalChannel.js';
-import { TicketType, PoliticalEventType, AppointmentDetails } from '../../types/events.js';
-import { CollectorType } from '../../types/collector.js';
-import ExtendedClient from '../../discord/ExtendedClient.js';
-import BaseCollector, { BaseCollectorModel } from './BaseCollector.js';
+import GuildModel from '../main/PoliticalGuild.ts';
+import EventModel, { EventSchema } from '../events/Event.ts';
+import { PoliticalChannelModel } from '../channels/PoliticalChannel.ts';
+import { TicketType, PoliticalEventType, AppointmentDetails } from '../../types/events.ts';
+import { CollectorType } from '../../types/collector.ts';
+import ExtendedClient from '../../discord/ExtendedClient.ts';
+import BaseCollector, { BaseCollectorModel } from './BaseCollector.ts';
 
 import type { TextChannel } from 'discord.js';
-import type { DefaultInteractionData } from '../../types/collector.js';
+import type { DefaultInteractionData } from '../../types/collector.ts';
 
 
 /**

--- a/src/schema/events/Event.ts
+++ b/src/schema/events/Event.ts
@@ -5,7 +5,7 @@ import {
 
 import AppointmentOptions from '../options/EventOptions.js';
 import GuildModel from '../main/PoliticalGuild.js';
-import MiddlewareManager from '../../utils/MiddlewareManager.js';
+import middlewareManager from '../../utils/MiddlewareManager.js';
 import { PoliticalEventType } from '../../types/events.js';
 
 
@@ -14,7 +14,7 @@ import { PoliticalEventType } from '../../types/events.js';
  * 
  * @class
  */
-@post<EventSchema>('save', (new MiddlewareManager).createEventMiddleware())
+@post<EventSchema>('save', EventSchema.obtainEventMiddleware())
 class EventSchema {
   @prop({ required: true })
   public name!: string;
@@ -70,7 +70,7 @@ class EventSchema {
   // Statics
   public static obtainEventMiddleware() {
     return async (doc: DocumentType<EventSchema>) => {
-      const client = (new MiddlewareManager).getClient();
+      const client = middlewareManager.getClient();
 
       // Find the Server Log channel from the LogChannelHolder
       const guild = await GuildModel.findOne({ guildID: doc.guildID });

--- a/src/schema/events/Event.ts
+++ b/src/schema/events/Event.ts
@@ -3,10 +3,10 @@ import {
   prop, getModelForClass, Severity, isDocument, post, type DocumentType,
 } from '@typegoose/typegoose';
 
-import AppointmentOptions from '../options/EventOptions.js';
-import GuildModel from '../main/PoliticalGuild.js';
-import middlewareManager from '../../utils/MiddlewareManager.js';
-import { PoliticalEventType } from '../../types/events.js';
+import AppointmentOptions from '../options/EventOptions.ts';
+import GuildModel from '../main/PoliticalGuild.ts';
+import middlewareManager from '../../utils/MiddlewareManager.ts';
+import { PoliticalEventType } from '../../types/events.ts';
 
 
 /**

--- a/src/schema/main/Chamber.ts
+++ b/src/schema/main/Chamber.ts
@@ -3,14 +3,14 @@ import {
   type Ref,
 } from '@typegoose/typegoose';
 
-import { ThresholdOptions, TermOptions, SeatOptions } from '../options/RoleOptions.js';
+import { ThresholdOptions, TermOptions, SeatOptions } from '../options/RoleOptions.ts';
 import {
   PoliticalBranchType, LegislativeChamberType, PoliticalSystemType
-} from '../../types/systems.js';
-import GuildModel from './PoliticalGuild.js';
+} from '../../types/systems.ts';
+import GuildModel from './PoliticalGuild.ts';
 
-import type PoliticalChannel from '../channels/PoliticalChannel.js';
-import type { GuildConfigData } from '../../types/wizard.js';
+import type PoliticalChannel from '../channels/PoliticalChannel.ts';
+import type { GuildConfigData } from '../../types/wizard.ts';
 
 
 /**

--- a/src/schema/main/PoliticalGuild.ts
+++ b/src/schema/main/PoliticalGuild.ts
@@ -1,16 +1,16 @@
 import { getModelForClass, prop, type Ref } from '@typegoose/typegoose';
 
 
-import PoliticalRoleHolder from '../roles/PoliticalRoleHolder.js';
-import PoliticalRole from '../roles/PoliticalRole.js';
-import LogChannelHolder from '../channels/LogChannelHolder.js';
-import GuildCategory from '../channels/GuildCategory.js';
-import PoliticalSystem from './PoliticalSystem.js';
+import PoliticalRoleHolder from '../roles/PoliticalRoleHolder.ts';
+import PoliticalRole from '../roles/PoliticalRole.ts';
+import LogChannelHolder from '../channels/LogChannelHolder.ts';
+import GuildCategory from '../channels/GuildCategory.ts';
+import PoliticalSystem from './PoliticalSystem.ts';
 
 import type { ChatInputCommandInteraction, Guild } from 'discord.js';
-import type EmergencyOptions from '../options/MiscOptions.js';
-import type { EventSchema } from '../events/Event.js';
-import type { GuildConfigData } from '../../types/wizard.js';
+import type EmergencyOptions from '../options/MiscOptions.ts';
+import type { EventSchema } from '../events/Event.ts';
+import type { GuildConfigData } from '../../types/wizard.ts';
 
 
 class PoliticalGuild {

--- a/src/schema/main/PoliticalSystem.ts
+++ b/src/schema/main/PoliticalSystem.ts
@@ -3,11 +3,11 @@ import {
   type Ref
 } from '@typegoose/typegoose';
 
-import { TermOptions } from '../options/RoleOptions.js';
-import { PoliticalSystemType, PoliticalBranchType, type DDOptions } from '../../types/systems.js';
+import { TermOptions } from '../options/RoleOptions.ts';
+import { PoliticalSystemType, PoliticalBranchType, type DDOptions } from '../../types/systems.ts';
 import Chamber, { type Legislature, type Senate, type Referendum, type Court } from "./Chamber.js";
 
-import type { GuildConfigData } from '../../types/wizard.js';
+import type { GuildConfigData } from '../../types/wizard.ts';
 
 
 @modelOptions({ schemaOptions: { collection: "politicalsystems" } })

--- a/src/schema/options/EventOptions.ts
+++ b/src/schema/options/EventOptions.ts
@@ -1,7 +1,7 @@
 import { prop, type Ref } from '@typegoose/typegoose';
 
-import PoliticalRole from '../roles/PoliticalRole.js';
-import { AppointmentDetails } from '../../types/events.js';
+import PoliticalRole from '../roles/PoliticalRole.ts';
+import { AppointmentDetails } from '../../types/events.ts';
 
 class AppointmentOptions {
   /**

--- a/src/schema/roles/PoliticalRole.ts
+++ b/src/schema/roles/PoliticalRole.ts
@@ -4,15 +4,15 @@ import { prop, type Ref, getModelForClass } from '@typegoose/typegoose';
 import {
   parsePermissionsAggregate,
   progressivePermissionsAllocator
-} from '../../utils/permissionsHelper.js';
+} from '../../utils/permissionsHelper.ts';
 import {
   PoliticalRoleHierarchy,
   type BasePermissionsAggregate
-} from '../../types/permissions.js';
-import PoliticalRoleHolder from './PoliticalRoleHolder.js';
+} from '../../types/permissions.ts';
+import PoliticalRoleHolder from './PoliticalRoleHolder.ts';
 
 
-import type { GuildConfigData } from '../../types/wizard.js';
+import type { GuildConfigData } from '../../types/wizard.ts';
 
 
 class PoliticalRole {

--- a/src/utils/MiddlewareManager.ts
+++ b/src/utils/MiddlewareManager.ts
@@ -1,5 +1,3 @@
-import { EventSchema } from "../schema/events/Event.js";
-
 import type ExtendedClient from "../discord/ExtendedClient.js";
 
 
@@ -9,17 +7,7 @@ import type ExtendedClient from "../discord/ExtendedClient.js";
  * This can be put in globals if there are more middleware to manage (For now in utils).
  */
 class MiddlewareManager {
-  private static instance: MiddlewareManager;
   private client!: ExtendedClient;
-
-  constructor() {
-    // Make sure singleton
-    if (MiddlewareManager.instance) {
-      return MiddlewareManager.instance;
-    } else {
-      MiddlewareManager.instance = this;
-    }
-  }
 
   public setClient(client: ExtendedClient) {
     this.client = client;
@@ -28,10 +16,8 @@ class MiddlewareManager {
   public getClient() {
     return this.client;
   }
-
-  public createEventMiddleware() {
-    return EventSchema.obtainEventMiddleware();
-  }
 }
 
-export default MiddlewareManager;
+const middlewareManager = new MiddlewareManager();
+
+export { MiddlewareManager, middlewareManager as default };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "esnext",
     "moduleResolution": "bundler",
     "moduleDetection": "force",
-    "noEmit": false,
+    "noEmit": true,
     "outDir": "./build",
     "rootDir": "./src",
     "sourceMap": true,
@@ -19,6 +19,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "resolveJsonModule": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*.ts", "src/**/*.json"],
 }


### PR DESCRIPTION
This pull request uses newer versions of node (currently on v24) to directly run program from typescript without transpiling to js. Therefore, certain build processes are now unused.

This also fixes certain issues associated with moving runtime environment from v20 to v24 (such as assert -> with syntax).

